### PR TITLE
Feature/add cache layer

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,11 +1,25 @@
 version: '3.8'
 services:
+  redis-tests:
+    image: redis:latest
+    container_name: redis-test-cache
+    ports:
+      - "6380:6379"
+    volumes:
+      - redis_data:/test_data 
   tests:
+    container_name: big-core-tests
     build:
       context: .
       dockerfile: src/backend/Dockerfile.test
+    depends_on:
+      - redis-tests
     env_file:
       - ./src/backend/.env
     environment:
-      DOTNET_ENVIRONMENT: Development
-      ASPNETCORE_ENVIRONMENT: Development
+      - ASPNETCORE_ENVIRONMENT=Development
+      - REDIS_CONNECTION=redis-tests:6379
+
+volumes:
+  redis_data:
+    driver: local 

--- a/docker-compose.tests.yml
+++ b/docker-compose.tests.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "6380:6379"
     volumes:
-      - redis_data:/test_data 
+      - redis_data:/test_data
   tests:
     container_name: big-core-tests
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:latest
+    container_name: redis-cache
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data 
+  app:
+    container_name: big_core_BFF
+    build: 
+      context: ./src/backend/
+      dockerfile: Dockerfile
+    env_file:
+      - ./src/backend/.env
+    ports:
+      - "80:80"
+    depends_on:
+      - redis
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Release
+      - REDIS_CONNECTION=redis:6379
+
+volumes:
+  redis_data:
+    driver: local 

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+
+COPY big_core.Api/big_core.Api.csproj big_core.Api/
+COPY big_core.Common/big_core.Common.csproj big_core.Common/
+
+RUN dotnet restore "big_core.Api/big_core.Api.csproj"
+
+COPY . .
+
+WORKDIR "/big_core.Api"
+
+RUN dotnet build "big_core.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet publish "big_core.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+EXPOSE 80
+EXPOSE 403
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=http://+:80
+
+ENTRYPOINT ["dotnet", "big_core.Api.dll"]

--- a/src/backend/big_core.Api/Helpers/DependencyRegistryExtension.cs
+++ b/src/backend/big_core.Api/Helpers/DependencyRegistryExtension.cs
@@ -1,5 +1,6 @@
 using big_core.Api.Models.DTO;
 using big_core.Api.Repository.Odometer;
+using big_core.Api.Services.Cache;
 using big_core.Api.Services.Odometer;
 using big_core.Api.Validators;
 using big_core.Common;
@@ -37,6 +38,9 @@ namespace big_core.Api.Helpers
         {
             services.AddScoped<IValidator<GetOdometerTrackerListFilterDTO>, GetOdometerTrackerListFilterValidator>();
             services.AddScoped<IOdometerService, OdometerWebService>();
+
+            services.RegisterRedisConnection();
+            services.AddScoped<ICacheService, RedisCacheService>();
             return services;
         }
     }

--- a/src/backend/big_core.Api/Helpers/ErrorMessages.cs
+++ b/src/backend/big_core.Api/Helpers/ErrorMessages.cs
@@ -2,6 +2,7 @@ namespace big_core.Api.Helpers;
 
 public static class ErrorMessages
 {
+    public const string REQUIRED_ENVIRONMENT_VARIABLE_MISSING = "REQUIRED ENVIRONMENT VALUE WAS NOT FOUND";
     public const string REQUIRED_START_DATE = "Start date is required";
     public const string REQUIRED_END_DATE = "End date is required";
     public const string API_REQUEST_FAILED_ERROR = "API request failed";

--- a/src/backend/big_core.Api/Helpers/RedisConfigurationExtension.cs
+++ b/src/backend/big_core.Api/Helpers/RedisConfigurationExtension.cs
@@ -1,0 +1,17 @@
+using big_core.Common;
+using StackExchange.Redis;
+
+namespace big_core.Api.Helpers
+{
+    public static class RedisConfigurationExtension
+    {
+        public static IServiceCollection RegisterRedisConnection(this IServiceCollection services)
+        {
+            var redisConnectionString = Environment.GetEnvironmentVariable(CommonConstants.RedisConnectionVariableKey);
+            if (redisConnectionString is null) throw new Exception(ErrorMessages.REQUIRED_ENVIRONMENT_VARIABLE_MISSING);
+            services.AddSingleton<IConnectionMultiplexer>(ConnectionMultiplexer.Connect(redisConnectionString));
+
+            return services;
+        }
+    }
+}

--- a/src/backend/big_core.Api/Program.cs
+++ b/src/backend/big_core.Api/Program.cs
@@ -36,6 +36,7 @@ var app = builder.Build();
 app.UseSwagger();
 app.UseSwaggerUI(options =>
 {
+    options.DocumentTitle = "Big Core demo BFF API";
     options.SwaggerEndpoint("/swagger/v1/swagger.json", "Big Core demo BFF API");
     options.RoutePrefix = string.Empty;
 });

--- a/src/backend/big_core.Api/Services/Cache/ICacheService.cs
+++ b/src/backend/big_core.Api/Services/Cache/ICacheService.cs
@@ -1,0 +1,8 @@
+namespace big_core.Api.Services.Cache;
+
+public interface ICacheService
+{
+    Task SetAsync<T>(string key, T value, TimeSpan expiration);
+    Task<T?> GetAsync<T>(string key);
+    Task RemoveAsync(string key);
+}

--- a/src/backend/big_core.Api/Services/Cache/RedisCacheService.cs
+++ b/src/backend/big_core.Api/Services/Cache/RedisCacheService.cs
@@ -1,0 +1,26 @@
+namespace big_core.Api.Services.Cache;
+
+using StackExchange.Redis;
+using System.Text.Json;
+
+public class RedisCacheService(IConnectionMultiplexer redis) : ICacheService
+{
+    private readonly IDatabase _cache = redis.GetDatabase();
+
+    public async Task SetAsync<T>(string key, T value, TimeSpan expiration)
+    {
+        var jsonData = JsonSerializer.Serialize(value);
+        await _cache.StringSetAsync(key, jsonData, expiration);
+    }
+
+    public async Task<T?> GetAsync<T>(string key)
+    {
+        var jsonData = await _cache.StringGetAsync(key);
+        return jsonData.HasValue ? JsonSerializer.Deserialize<T>(jsonData!) : default;
+    }
+
+    public async Task RemoveAsync(string key)
+    {
+        await _cache.KeyDeleteAsync(key);
+    }
+}

--- a/src/backend/big_core.Api/big_core.Api.csproj
+++ b/src/backend/big_core.Api/big_core.Api.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="FluentResults" Version="3.16.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.31" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/src/backend/big_core.Common/CommonConstants.cs
+++ b/src/backend/big_core.Common/CommonConstants.cs
@@ -4,5 +4,6 @@ public static class CommonConstants
 {
     public const string ApiBaseUrlKey = "API_BASE_URL";
     public const string ApiAuthHeaderTokenKey = "API_AUTH_HEADER_TOKEN";
+    public const string RedisConnectionVariableKey = "REDIS_CONNECTION";
     public const int RangeLimitForOdometerTrackDateSearch = 90;
 }

--- a/src/backend/big_core.Tests/Integration/Repositories/OdometerRepository/FakeCacheService.cs
+++ b/src/backend/big_core.Tests/Integration/Repositories/OdometerRepository/FakeCacheService.cs
@@ -1,0 +1,20 @@
+namespace big_core.Tests.Integration.Repositories.OdometerRepository;
+using big_core.Api.Services.Cache;
+
+public class FakeCacheService : ICacheService
+{
+    public Task<T?> GetAsync<T>(string key)
+    {
+        return Task.FromResult<T?>(default);
+    }
+
+    public Task SetAsync<T>(string key, T value, TimeSpan expiration)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveAsync(string key)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/backend/big_core.Tests/Integration/Repositories/OdometerRepository/OdometerRepositoryFixture.cs
+++ b/src/backend/big_core.Tests/Integration/Repositories/OdometerRepository/OdometerRepositoryFixture.cs
@@ -3,6 +3,7 @@ namespace big_core.Tests.Integration.Repositories.OdometerRepository;
 using Microsoft.Extensions.DependencyInjection;
 using big_core.Api.Repository.Odometer;
 using big_core.Api.Helpers;
+using big_core.Api.Services.Cache;
 
 [CollectionDefinition("OdometerRepository Collection")]
 public class OdometerRepositoryCollection : ICollectionFixture<OdometerRepositoryFixture> { }
@@ -15,7 +16,7 @@ public class OdometerRepositoryFixture
     {
         var serviceCollection = new ServiceCollection();
         serviceCollection.RegisterHttpFactoryInstance();
-
+        serviceCollection.AddScoped<ICacheService, FakeCacheService>();
         var serviceProvider = serviceCollection.BuildServiceProvider();
         OdometerRepository = serviceProvider.GetRequiredService<IOdometerRepository>();
     }


### PR DESCRIPTION
This PR adds cache logic to 'IOdometerRepository' to avoid unnecessary hits to external API.

Adds StackExchange.Redis as a dependency;
Creates an interface and its implementations (REDIS client and a testing one) for caching;
Configures necessary files to build the main backend container containing the BFF API and a REDIS container;
Configures the docker compose for tests to include a specific REDIS container to handle the E2E/Integration tests;